### PR TITLE
Fix: for nav and landing page buttons

### DIFF
--- a/app/views/home/_hero.html.erb
+++ b/app/views/home/_hero.html.erb
@@ -9,7 +9,7 @@
       <% if user_signed_in? %>
         <%= link_to "Start Mentorship", dashboard_path(role: current_user.role )%>
       <% else %>
-        <%= link_to "Start Mentorship", new_user_session_path %>
+        <%= link_to "Start Mentorship", mentor_mentee_registration_path %>
       <% end %>
     </button>
   </div>

--- a/app/views/shared/_landing_nav.html.erb
+++ b/app/views/shared/_landing_nav.html.erb
@@ -21,7 +21,7 @@
         </div>
         <div class="text-s font-medium bg-[#202020] text-[#FFFFFF] border border-transparent rounded-md
              py-2 px-5 mr-auto hover:scale-105">
-          <%= link_to "Sign out", destroy_user_session_path, method: :delete, data: { turbo: false } %>
+          <%= button_to "Sign Out", destroy_user_session_path, method: :delete, data: { turbo: false } %>
         </div>
       </div>
     <% else %>


### PR DESCRIPTION
- The sign-out button on the new nav now works
- When signed out the "Start Mentorship" button on the landing page, goes to the signup page and not to the login page