### PR TITLE
Fixing user scopes for cohort member relation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,15 +42,15 @@ class User < ApplicationRecord
 
   # Returns list of mentees that are in the same cohort as the provided mentor
   scope :mentors_in_cohort, lambda { |cohort|
-                              joins(:cohort_members)
+                              joins(:cohort_member)
                                 .where('cohort_members.cohort_id = ? AND cohort_members.role = ?', cohort, 'mentor')
                             }
   scope :mentees_in_cohort, lambda { |cohort|
-                              joins(:cohort_members)
+                              joins(:cohort_member)
                                 .where('cohort_members.cohort_id = ? AND cohort_members.role = ?', cohort, 'mentee')
                             }
   scope :unpaired_mentees_in_cohort, lambda { |cohort|
-                                       joins(:cohort_members)
+                                       joins(:cohort_member)
                                          .left_joins('LEFT JOIN matches ON matches.mentee_id = users.id AND matches.active = true')
                                          .where('cohort_members.cohort_id = ? AND cohort_members.role = ?', cohort, 'mentee')
                                          .where('matches.id IS NULL')


### PR DESCRIPTION
- This PR fixes the errors with the user's scopes caused by changing the association between the User model and the CohortMember model.