### PR TITLE
127 ta ms handling matching aftermath

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -75,6 +75,10 @@ class MatchesController < ApplicationController
     end
 
     Rails.logger.info "Finished match creation for cohort ##{cohort_id} at #{Time.current}"
+
+    #TODO: might need to be a background job
+    cohort = Cohort.find_by(id: cohort_id)
+    cohort.send_matching_results_emails
   end
 
   # PATCH/PUT /matches/1 or /matches/1.json

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -38,7 +38,7 @@ class MatchesController < ApplicationController
   private
   
   def create_matches_for_cohort(cohort_id)
-    sorted_shortlist = ShortList.where(cohort_id: cohort_id).order(:ranking, :created_at)
+    sorted_shortlist = ShortList.where(cohort_id: cohort_id).order(:created_at, :ranking)
     Rails.logger.info "Starting match creation for cohort ##{cohort_id} at #{Time.current}"
 
     sorted_shortlist.each do |shortlist|

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -65,4 +65,22 @@ class Cohort < ApplicationRecord
       end
     end
   end
+  def send_matching_results_emails
+    emails_of_cohort_members = CohortMember.where(cohort_id: self.id).pluck(:email)
+    matched_users = []
+    unmatched_users = []
+
+    emails_of_cohort_members.each do |email|
+      user = User.find_by(email: email)
+
+      if user.matched?
+        matched_users << user.email
+      else
+        unmatched_users << user.email
+      end
+    end
+    p matched_users
+    p unmatched_users
+    p "Emails sent"
+  end
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -107,6 +107,7 @@ class Cohort < ApplicationRecord
       if user.matched?
         matched_users << user
       else
+        ShortList.where(mentee_id: user.id).destroy_all
         unmatched_users << user
       end
     end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -59,8 +59,10 @@ class Cohort < ApplicationRecord
         require 'rufus-scheduler'
         # Initialize a new scheduler instance
         scheduler = Rufus::Scheduler.new
-        cohorts = Cohort.where.not(shortlist_start_time: nil)
-              .where.not(shortlist_end_time: nil)
+        cohorts = Cohort.where.not(start_date: nil)
+          .where.not(end_date: nil)
+          .where.not(shortlist_start_time: nil)
+          .where.not(shortlist_end_time: nil)
 
         cohorts.each do |cohort|
           shortlist_end_date = cohort.shortlist_end_time.in_time_zone.utc
@@ -122,6 +124,6 @@ class Cohort < ApplicationRecord
       # send email to admin that matching is complete (if all mentees are matched)
       CohortMailer.matching_complete_notification(self.creator.email, self).deliver_later
     end
-    p "Emails sent"
+    p "Emails sent for unmactched users"
   end
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -74,9 +74,9 @@ class Cohort < ApplicationRecord
       user = User.find_by(email: email)
 
       if user.matched?
-        matched_users << user.email
+        matched_users << user
       else
-        unmatched_users << user.email
+        unmatched_users << user
       end
     end
     p matched_users

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -21,8 +21,14 @@ class Cohort < ApplicationRecord
   belongs_to :program, required: true, class_name: "Program", foreign_key: "program_id"
   has_many :members, class_name: "CohortMember", foreign_key: "cohort_id", dependent: :destroy
   has_many :matches, class_name: "Match", foreign_key: "cohort_id", dependent: :destroy
+
+  validates :start_date, presence: { message: "Start Date cannot be blank" }
+  validates :end_date, presence: { message: "End Date be blank" }
+  validates :shortlist_start_time, presence: { message: "Shortlist start time cannot be blank" }
+  validates :shortlist_end_time, presence: { message: "Shortlist end time cannot be blank" }
+  validates :required_meetings, presence: { message: "Required meetings cannot be blank" }
   
-  after_commit :start_scheduler_on_creation, on: [:create, :update, :destroy]
+  after_commit :start_scheduler_thread, on: [:create, :update, :destroy]
 
   def running?
     if end_date > Date.today
@@ -46,7 +52,7 @@ class Cohort < ApplicationRecord
   end
 
   # Creates thread that runs matching code in matches controller
-  def start_scheduler_on_creation
+  def start_scheduler_thread
     unless  @scheduler_thread&.alive?
       Rails.logger.info "Creating new scheduler thread..."
       @scheduler_thread = Thread.new(name: 'MatchingThreadInCohortModel') do
@@ -56,48 +62,34 @@ class Cohort < ApplicationRecord
         cohorts = Cohort.where.not(shortlist_start_time: nil)
               .where.not(shortlist_end_time: nil)
 
-        # trigger email when the scheduler is reached
         cohorts.each do |cohort|
+          shortlist_end_date = cohort.shortlist_end_time.in_time_zone.utc
+
+          # trigger matching when the scheduler is reached
+          scheduler.at shortlist_end_date do
+            MatchesController.new.create_for_cohort(cohort)
+          end
+        
           # Schedule the email notification at the shortlist start time
           scheduler.at cohort.shortlist_start_time.in_time_zone.utc do
             cohort.members.each do |member|
               CohortMailer.shortlist_start_notification(member.user, cohort).deliver_later
             end
           end
-        end
 
-        cohorts.each_with_index do |cohort, index|
-          shortlist_end_date = cohort.shortlist_end_time.in_time_zone.utc
-          scheduler.at shortlist_end_date do
-            MatchesController.new.create_for_cohort(cohort)
-            unmatched_mentees = cohort.members.where(role: 'mentee').where.not(id: cohort.matches.pluck(:mentee_id))
-            
-            # if there are any unmatched mentees
-            if unmatched_mentees.any?
-              unmatched_mentees.each do |mentee|
-                # send them email
-                CohortMailer.unmatched_notification(mentee.user, cohort).deliver_later
-              end
-              # and update the shortlist time to add 3 more days 
-              cohort.update(shortlist_end_time: 3.days.from_now)
-            else
-              # send email to admin that matching is complete
-              CohortMailer.matching_complete_notification(cohort.creator.email, cohort).deliver_later
+          # send warning email to admin that cohort is ending in 2 weeks
+          scheduler.at cohort.end_date - 2.weeks do
+            CohortMailer.two_week_warning(creator.email, cohort).deliver_later
+
+            cohort_members = CohortMember.where(cohort_id: cohort.id)
+            # remind each cohort member about survey
+            cohort_members.each do |member|
+              CohortMailer.survey_reminder(member.mentor, cohort).deliver_later
+              CohortMailer.survey_reminder(member.mentee, cohort).deliver_later
             end
-          end
-        end
-        
-        # send warning email to admin that cohort is ending in 2 weeks
-        scheduler.at end_date - 2.weeks do
-          CohortMailer.two_week_warning(creator.email, self).deliver_later
-          
-          # remind each cohort member about survey
-          matches.each do |match|
-            CohortMailer.survey_reminder(match.mentor, self).deliver_later
-            CohortMailer.survey_reminder(match.mentee, self).deliver_later
-          end
 
-          CohortMailer.survey_reminder(nil, self, creator.email).deliver_later
+            CohortMailer.survey_reminder(nil, cohort, cohort.creator.email).deliver_later
+          end
         end
       end
     end
@@ -106,7 +98,7 @@ class Cohort < ApplicationRecord
     emails_of_cohort_members = CohortMember.where(cohort_id: self.id).pluck(:email)
     matched_users = []
     unmatched_users = []
-
+    
     emails_of_cohort_members.each do |email|
       user = User.find_by(email: email)
 
@@ -116,8 +108,20 @@ class Cohort < ApplicationRecord
         unmatched_users << user
       end
     end
-    p matched_users
-    p unmatched_users
+    p "matched emails #{matched_users}"
+    p "unmatched emails #{unmatched_users}"
+
+    # if there are any unmatched mentees
+    if unmatched_users.any?
+      unmatched_users.each do |user|
+        # opens shortlist creation again for 3 days
+        self.update!(shortlist_end_time: shortlist_end_time + 3.days)
+        CohortMailer.unmatched_notification(user, self).deliver_later
+      end
+    else
+      # send email to admin that matching is complete (if all mentees are matched)
+      CohortMailer.matching_complete_notification(self.creator.email, self).deliver_later
+    end
     p "Emails sent"
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -21,6 +21,7 @@ class Match < ApplicationRecord
   after_create :send_match_created_email
 
   def send_match_created_email
+     p "Emails sent matched users"
     MatchMailer.match_created(self).deliver_later
   end
 end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -8,14 +8,39 @@ Rails.application.config.to_prepare do
     require 'rufus-scheduler'
     # Initialize a new scheduler instance
     scheduler = Rufus::Scheduler.new
-    cohorts = Cohort.where.not(shortlist_start_time: nil)
+    cohorts = Cohort.where.not(start_date: nil)
+          .where.not(end_date: nil)
+          .where.not(shortlist_end_time: nil)
           .where.not(shortlist_end_time: nil)
 
-    cohorts.each_with_index do |cohort, index|
+    cohorts.each do |cohort|
       shortlist_end_date = cohort.shortlist_end_time.in_time_zone.utc
+
+      # trigger matching when the scheduler is reached
       scheduler.at shortlist_end_date do
         MatchesController.new.create_for_cohort(cohort)
       end
+    
+      # Schedule the email notification at the shortlist start time
+      scheduler.at cohort.shortlist_start_time.in_time_zone.utc do
+        cohort.members.each do |member|
+          CohortMailer.shortlist_start_notification(member.user, cohort).deliver_later
+        end
+      end
+
+      # send warning email to admin that cohort is ending in 2 weeks
+      scheduler.at cohort.end_date - 2.weeks do
+        CohortMailer.two_week_warning(creator.email, cohort).deliver_later
+
+        cohort_members = CohortMember.where(cohort_id: cohort.id)
+        # remind each cohort member about survey
+        cohort_members.each do |member|
+          CohortMailer.survey_reminder(member.mentor, cohort).deliver_later
+          CohortMailer.survey_reminder(member.mentee, cohort).deliver_later
+        end
+
+        CohortMailer.survey_reminder(nil, cohort, cohort.creator.email).deliver_later
+      end
     end
-  end 
+  end
 end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
     scheduler = Rufus::Scheduler.new
     cohorts = Cohort.where.not(start_date: nil)
           .where.not(end_date: nil)
-          .where.not(shortlist_end_time: nil)
+          .where.not(shortlist_start_time: nil)
           .where.not(shortlist_end_time: nil)
 
     cohorts.each do |cohort|
@@ -23,8 +23,9 @@ Rails.application.config.to_prepare do
     
       # Schedule the email notification at the shortlist start time
       scheduler.at cohort.shortlist_start_time.in_time_zone.utc do
+        p "Shortlist Open Email sent for cohort ##{cohort.id}"
         cohort.members.each do |member|
-          CohortMailer.shortlist_start_notification(member.user, cohort).deliver_later
+          # CohortMailer.shortlist_start_notification(member.user, cohort).deliver_later
         end
       end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,13 +78,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_07_213142) do
   end
 
   create_table "program_admins", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.string "email", null: false
     t.bigint "program_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role"
+    t.index ["email"], name: "index_program_admins_on_email"
     t.index ["program_id"], name: "index_program_admins_on_program_id"
-    t.index ["user_id"], name: "index_program_admins_on_user_id"
   end
 
   create_table "programs", force: :cascade do |t|


### PR DESCRIPTION
- After matching takes place
     - Emails are prepared to be sent for those who were matched and not matched (@brvarner & @borvux will finalize )
     - Mentee's 2nd dashboard displays to see mentor if matched
     - If user is not matched, shortlist is deleted and shortlist creation reopens
     - Adds 3 days for second round only for unmatched mentees
- Mentees who didn't send a shortlist also go through the reopening phase

- Sample data has been updated for shortlists and cohorts

closes #127